### PR TITLE
Ensure closing the previous connection when reconnecting.

### DIFF
--- a/lib/reconnecting-proxy.js
+++ b/lib/reconnecting-proxy.js
@@ -135,7 +135,9 @@ var ReconnectingProxy = (function (_Emitter) {
       }).on("favorite", function (event) {
         return _this.emit("favorite", event);
       }).on("error", function (err) {
-        return _this.reconnect(err);
+        _this.client.once("end", function () {
+          return _this.reconnect(err);
+        }).close();
       });
 
       this.setReconnectingCheckTimer();
@@ -187,6 +189,10 @@ var ReconnectingProxy = (function (_Emitter) {
         return this.close();
       }
 
+      if (err) {
+        log(err + " occurred");
+      }
+
       if (this.reconnectingTriedCount > this.reconnectingMaxCount) {
         log("reconnecting tried " + this.reconnectingMaxCount + ", abort");
         this.emit("error", this.lastError);
@@ -198,23 +204,33 @@ var ReconnectingProxy = (function (_Emitter) {
         this.reconnectingCheckTimer = void 0;
       }
 
+      var _getBackoffStrategySpec = this.getBackoffStrategySpec(err);
+
+      var _getBackoffStrategySpec2 = _slicedToArray(_getBackoffStrategySpec, 2);
+
+      var interval = _getBackoffStrategySpec2[0];
+      var maxCount = _getBackoffStrategySpec2[1];
+
       var delay;
 
       if (this.reconnectingTimer) {
         clearTimeout(this.reconnectingTimer);
-        this.reconnectingTriedCount += 1;
-        delay = this.reconnectingInterval * Math.pow(2, this.reconnectingTriedCount - 1);
+
+        if (interval > this.reconnectingInterval) {
+          // if the interval calculated newly exceeds
+          // `this.reconnectingInterval`, use this.
+          this.reconnectingInterval = interval;
+          this.reconnectingMaxCount = maxCount;
+          this.reconnectingTriedCount = 0;
+          delay = 0;
+        } else {
+          this.reconnectingTriedCount += 1;
+          delay = this.reconnectingInterval * Math.pow(2, this.reconnectingTriedCount - 1);
+        }
       } else {
-        this.lastError = err;
+        this.reconnectingInterval = interval;
+        this.reconnectingMaxCount = maxCount;
         this.reconnectingTriedCount = 0;
-
-        var _getBackoffStrategySpec = this.getBackoffStrategySpec(err);
-
-        var _getBackoffStrategySpec2 = _slicedToArray(_getBackoffStrategySpec, 2);
-
-        this.reconnectingInterval = _getBackoffStrategySpec2[0];
-        this.reconnectingMaxCount = _getBackoffStrategySpec2[1];
-
         delay = 0;
       }
 

--- a/test/reconnecting-proxy.spec.js
+++ b/test/reconnecting-proxy.spec.js
@@ -1,0 +1,27 @@
+import Emitter from "component-emitter";
+import expect from "expect.js";
+import ReconnectingProxy from "../src/reconnecting-proxy";
+import sinon from "sinon";
+
+class FakeClient extends Emitter {
+  open() { return this; }
+  close() { return this; }
+}
+
+describe("ReconnectingProxy", () => {
+  beforeEach(function() {
+    this.fakeClient = new FakeClient();
+  });
+
+  describe("when an `error` event is emitted from the client", () => {
+    it("should close client", function() {
+      var proxy = new ReconnectingProxy(this.fakeClient);
+      var spy = sinon.spy(this.fakeClient, "close");
+
+      proxy.open();
+      this.fakeClient.emit("error", "abc");
+
+      expect(spy.called).to.be.ok();
+    });
+  });
+});

--- a/test/reconnecting.spec.js
+++ b/test/reconnecting.spec.js
@@ -5,6 +5,8 @@ import ReconnectingProxy from "../src/reconnecting-proxy";
 import sinon from "sinon";
 import TwitterStreamClient from "../src/client";
 
+// This test intends for integration test.
+
 // Dummy response class to test delayed response.
 class DelayedResponse extends Readable {
   constructor(interval) {


### PR DESCRIPTION
When reconnecting, ensure closing the previous connection and adopt a backoff strategy which has longer interval.

closes #2.
